### PR TITLE
Null instead of blank.

### DIFF
--- a/setup/install/queries.json
+++ b/setup/install/queries.json
@@ -7,7 +7,7 @@
                 "name": "discord_id",
                 "type": "VARCHAR",
                 "length": 64,
-                "default": ""
+                "default": null
             }
         ]
     },
@@ -17,7 +17,7 @@
             "core_members",
             {
                 "name": "discord_token",
-                "type": "TEXT"
+                "default": null
             }
         ]
     },


### PR DESCRIPTION
Makes more sense to record it (discord_id , and discord_token) as null before association.